### PR TITLE
Add optional serde support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,6 @@ repository = "https://github.com/hyunsik/bytesize/"
 readme = "README.md"
 keywords = ["byte", "utility", "human-readable", "size", "format"]
 license = "Apache-2.0"
+
+[dependencies]
+serde = { version = "1.0", optional = true, features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,10 @@
 //!  assert_eq!("518 GB".to_string(), ByteSize::gb(518).to_string(false));
 //! ```
 
+#[cfg(feature = "serde")]
+#[macro_use]
+extern crate serde;
+
 use std::fmt::{Debug, Display, Formatter, Result};
 use std::ops::{Add, Mul};
 
@@ -61,6 +65,7 @@ static LN_KIB: f64 = 6.907755279; // ln 1000
 
 /// Byte size representation
 #[derive(Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ByteSize(pub u64);
 
 impl ByteSize {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,7 +176,7 @@ macro_rules! commutative_op {
             type Output = ByteSize;
             #[inline(always)]
             fn add(self, rhs: $t) -> ByteSize {
-                ByteSize (self.0 + (rhs as u64))
+                ByteSize(self.0 + (rhs as u64))
             }
         }
 
@@ -184,7 +184,7 @@ macro_rules! commutative_op {
             type Output = ByteSize;
             #[inline(always)]
             fn add(self, rhs: ByteSize) -> ByteSize {
-                ByteSize (rhs.0 + (self as u64))
+                ByteSize(rhs.0 + (self as u64))
             }
         }
 
@@ -192,7 +192,7 @@ macro_rules! commutative_op {
             type Output = ByteSize;
             #[inline(always)]
             fn mul(self, rhs: $t) -> ByteSize {
-                ByteSize (self.0 * (rhs as u64))
+                ByteSize(self.0 * (rhs as u64))
             }
         }
 
@@ -200,7 +200,7 @@ macro_rules! commutative_op {
             type Output = ByteSize;
             #[inline(always)]
             fn mul(self, rhs: ByteSize) -> ByteSize {
-                ByteSize (rhs.0 * (self as u64))
+                ByteSize(rhs.0 * (self as u64))
             }
         }
     };


### PR DESCRIPTION
This PR adds an optional cargo feature that adds `serde` support. This is essentially implemented in the manner suggested by the [Rust API guidelines](https://rust-lang-nursery.github.io/api-guidelines/interoperability.html#data-structures-implement-serdes-serialize-deserialize-c-serde)