### PR TITLE
Implement the FromStr trait for ByteSize

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,8 @@
 //!  assert_eq!("518 GB".to_string(), ByteSize::gb(518).to_string(false));
 //! ```
 
+mod parse;
+
 #[cfg(feature = "serde")]
 #[macro_use]
 extern crate serde;
@@ -58,8 +60,8 @@ pub const TIB: u64 = 1_099_511_627_776;
 /// bytes size for 1 pebibyte
 pub const PIB: u64 = 1_125_899_906_842_624;
 
-static UNITS: &'static str = "KMGTPE";
-static UNITS_SI: &'static str = "kMGTPE";
+static UNITS: &str = "KMGTPE";
+static UNITS_SI: &str = "kMGTPE";
 static LN_KB: f64 = 6.931471806; // ln 1024
 static LN_KIB: f64 = 6.907755279; // ln 1000
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -4,10 +4,9 @@ impl std::str::FromStr for ByteSize {
     type Err = String;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value.parse::<u64>() {
-            Ok(v) => return Ok(Self(v)), // simple case, bytes
-            Err(_) => {}
-        };
+        if let Ok(v) = value.parse::<u64>() {
+            return Ok(Self(v));
+        }
         let number: String = value
             .chars()
             .take_while(|c| c.is_digit(10) || c == &'.')

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -109,4 +109,22 @@ mod tests {
         assert!(parse("").is_err());
         assert!(parse("a124GB").is_err());
     }
+
+    #[test]
+    fn to_and_from_str() {
+        assert_eq!(
+            format!("{}", "128GB".parse::<ByteSize>().unwrap())
+                .parse::<ByteSize>()
+                .unwrap()
+                .0,
+            128 * Unit::GB
+        );
+        assert_eq!(
+            super::super::to_string("128.000 GiB".parse::<ByteSize>().unwrap().0, true)
+                .parse::<ByteSize>()
+                .unwrap()
+                .0,
+            128 * Unit::GIB
+        );
+    }
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,0 +1,43 @@
+use super::ByteSize;
+
+impl std::str::FromStr for ByteSize {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.parse::<u64>() {
+            Ok(v) => return Ok(Self(v)), // simple case, bytes
+            Err(_) => {},
+        };
+        todo!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::*;
+
+    #[test]
+    fn when_ok() {
+        // shortcut for writing test cases
+        fn parse(s: &str) -> u64 {
+            s.parse::<ByteSize>().unwrap().0
+        }
+
+        assert_eq!("0".parse::<ByteSize>().unwrap().0, 0);
+        assert_eq!(parse("0"), 0);
+        assert_eq!(parse("500"), 500);
+        assert_eq!(parse("1K"), 1 * MB);
+        assert_eq!(parse("1Ki"), 1 * KIB);
+        assert_eq!(parse("1.5Ki"), (1.5 * KIB as f64) as u64);
+        assert_eq!(parse("1KiB"), 1 * KIB);
+        assert_eq!(parse("1.5KiB"), (1.5 * KIB as f64) as u64);
+        assert_eq!(parse("3 MB"), 3 * MB);
+        assert_eq!(parse("4 MiB"), 4 * MIB);
+        assert_eq!(parse("6 GB"), 6 * GB);
+        assert_eq!(parse("4 GiB"), 4 * GIB);
+        assert_eq!(parse("88TB"), 88 * TB);
+        assert_eq!(parse("521TiB"), 521 * TIB);
+        assert_eq!(parse("8 PB"), 8 * PB);
+        assert_eq!(parse("12 PB"), 12 * PIB);
+    }
+}

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -148,18 +148,14 @@ mod tests {
 
     #[test]
     fn to_and_from_str() {
+        // shortcut for writing test cases
+        fn parse(s: &str) -> u64 {
+            s.parse::<ByteSize>().unwrap().0
+        }
+
+        assert_eq!(parse(&format!("{}", parse("128GB"))), 128 * Unit::GB);
         assert_eq!(
-            format!("{}", "128GB".parse::<ByteSize>().unwrap())
-                .parse::<ByteSize>()
-                .unwrap()
-                .0,
-            128 * Unit::GB
-        );
-        assert_eq!(
-            super::super::to_string("128.000 GiB".parse::<ByteSize>().unwrap().0, true)
-                .parse::<ByteSize>()
-                .unwrap()
-                .0,
+            parse(&super::super::to_string(parse("128.000 GiB"), true)),
             128 * Unit::GIB
         );
     }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -28,6 +28,7 @@ impl std::str::FromStr for ByteSize {
     }
 }
 
+/// todo: maybe a Unit type would be appropriate
 fn match_suffix(unit: &str) -> u64 {
     match unit.to_lowercase().as_str() {
         "k" | "kb" => super::KB,
@@ -46,7 +47,8 @@ fn match_suffix(unit: &str) -> u64 {
 
 #[cfg(test)]
 mod tests {
-    use super::super::*;
+    use super::*;
+    use super::super::{KB, KIB, MB, MIB, GB, GIB, TB, TIB, PB, PIB};
 
     #[test]
     fn when_ok() {
@@ -71,5 +73,16 @@ mod tests {
         assert_eq!(parse("521TiB"), 521 * TIB);
         assert_eq!(parse("8 PB"), 8 * PB);
         assert_eq!(parse("12 PiB"), 12 * PIB);
+    }
+
+    #[test]
+    fn when_err() {
+        // shortcut for writing test cases
+        fn parse(s: &str) -> Result<ByteSize, String> {
+            s.parse::<ByteSize>()
+        }
+
+        assert!(parse("").is_err());
+        assert!(parse("a124GB").is_err());
     }
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -155,7 +155,7 @@ mod tests {
 
         assert_eq!(parse(&format!("{}", parse("128GB"))), 128 * Unit::GB);
         assert_eq!(
-            parse(&super::super::to_string(parse("128.000 GiB"), true)),
+            parse(&crate::to_string(parse("128.000 GiB"), true)),
             128 * Unit::GIB
         );
     }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -51,33 +51,21 @@ enum Unit {
 }
 
 impl Unit {
-    const B: u64 = super::B;
-    const KB: u64 = super::KB;
-    const KIB: u64 = super::KIB;
-    const MB: u64 = super::MB;
-    const MIB: u64 = super::MIB;
-    const GB: u64 = super::GB;
-    const GIB: u64 = super::GIB;
-    const TB: u64 = super::TB;
-    const TIB: u64 = super::TIB;
-    const PB: u64 = super::PB;
-    const PIB: u64 = super::PIB;
-
     fn factor(&self) -> u64 {
         match self {
-            Self::Byte => Self::B,
+            Self::Byte => super::B,
             // power of tens
-            Self::KiloByte => Self::KB,
-            Self::MegaByte => Self::MB,
-            Self::GigaByte => Self::GB,
-            Self::TeraByte => Self::TB,
-            Self::PetaByte => Self::PB,
+            Self::KiloByte => super::KB,
+            Self::MegaByte => super::MB,
+            Self::GigaByte => super::GB,
+            Self::TeraByte => super::TB,
+            Self::PetaByte => super::PB,
             // power of twos
-            Self::KibiByte => Self::KIB,
-            Self::MebiByte => Self::MIB,
-            Self::GibiByte => Self::GIB,
-            Self::TebiByte => Self::TIB,
-            Self::PebiByte => Self::PIB,
+            Self::KibiByte => super::KIB,
+            Self::MebiByte => super::MIB,
+            Self::GibiByte => super::GIB,
+            Self::TebiByte => super::TIB,
+            Self::PebiByte => super::PIB,
         }
     }
 }
@@ -119,20 +107,20 @@ mod tests {
         assert_eq!("0".parse::<ByteSize>().unwrap().0, 0);
         assert_eq!(parse("0"), 0);
         assert_eq!(parse("500"), 500);
-        assert_eq!(parse("1K"), 1 * Unit::KB);
-        assert_eq!(parse("1Ki"), 1 * Unit::KIB);
-        assert_eq!(parse("1.5Ki"), (1.5 * Unit::KIB as f64) as u64);
-        assert_eq!(parse("1KiB"), 1 * Unit::KIB);
-        assert_eq!(parse("1.5KiB"), (1.5 * Unit::KIB as f64) as u64);
-        assert_eq!(parse("3 MB"), 3 * Unit::MB);
-        assert_eq!(parse("4 MiB"), 4 * Unit::MIB);
-        assert_eq!(parse("6 GB"), 6 * Unit::GB);
-        assert_eq!(parse("4 GiB"), 4 * Unit::GIB);
-        assert_eq!(parse("88TB"), 88 * Unit::TB);
-        assert_eq!(parse("521TiB"), 521 * Unit::TIB);
-        assert_eq!(parse("8 PB"), 8 * Unit::PB);
-        assert_eq!(parse("8P"), 8 * Unit::PB);
-        assert_eq!(parse("12 PiB"), 12 * Unit::PIB);
+        assert_eq!(parse("1K"), 1 * crate::KB);
+        assert_eq!(parse("1Ki"), 1 * crate::KIB);
+        assert_eq!(parse("1.5Ki"), (1.5 * crate::KIB as f64) as u64);
+        assert_eq!(parse("1KiB"), 1 * crate::KIB);
+        assert_eq!(parse("1.5KiB"), (1.5 * crate::KIB as f64) as u64);
+        assert_eq!(parse("3 MB"), 3 * crate::MB);
+        assert_eq!(parse("4 MiB"), 4 * crate::MIB);
+        assert_eq!(parse("6 GB"), 6 * crate::GB);
+        assert_eq!(parse("4 GiB"), 4 * crate::GIB);
+        assert_eq!(parse("88TB"), 88 * crate::TB);
+        assert_eq!(parse("521TiB"), 521 * crate::TIB);
+        assert_eq!(parse("8 PB"), 8 * crate::PB);
+        assert_eq!(parse("8P"), 8 * crate::PB);
+        assert_eq!(parse("12 PiB"), 12 * crate::PIB);
     }
 
     #[test]
@@ -153,10 +141,10 @@ mod tests {
             s.parse::<ByteSize>().unwrap().0
         }
 
-        assert_eq!(parse(&format!("{}", parse("128GB"))), 128 * Unit::GB);
+        assert_eq!(parse(&format!("{}", parse("128GB"))), 128 * crate::GB);
         assert_eq!(
             parse(&crate::to_string(parse("128.000 GiB"), true)),
-            128 * Unit::GIB
+            128 * crate::GIB
         );
     }
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -6,9 +6,41 @@ impl std::str::FromStr for ByteSize {
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         match value.parse::<u64>() {
             Ok(v) => return Ok(Self(v)), // simple case, bytes
-            Err(_) => {},
+            Err(_) => {}
         };
-        todo!()
+        let number: String = value
+            .chars()
+            .take_while(|c| c.is_digit(10) || c == &'.')
+            .collect();
+        match number.parse::<f64>() {
+            Ok(v) => {
+                let suffix: String = value
+                    .chars()
+                    .skip_while(|c| c.is_whitespace() || c.is_digit(10) || c == &'.')
+                    .collect();
+                Ok(Self((v * match_suffix(&suffix) as f64) as u64))
+            }
+            Err(error) => Err(format!(
+                "couldn't parse {:?} into a ByteSize, {}",
+                value, error
+            )),
+        }
+    }
+}
+
+fn match_suffix(unit: &str) -> u64 {
+    match unit.to_lowercase().as_str() {
+        "k" | "kb" => super::KB,
+        "ki" | "kib" => super::KIB,
+        "m" | "mb" => super::MB,
+        "mi" | "mib" => super::MIB,
+        "g" | "gb" => super::GB,
+        "gi" | "gib" => super::GIB,
+        "t" | "tb" => super::TB,
+        "ti" | "tib" => super::TIB,
+        "p" | "pb" => super::PB,
+        "pi" | "pib" => super::PIB,
+        _ => 1,
     }
 }
 
@@ -26,7 +58,7 @@ mod tests {
         assert_eq!("0".parse::<ByteSize>().unwrap().0, 0);
         assert_eq!(parse("0"), 0);
         assert_eq!(parse("500"), 500);
-        assert_eq!(parse("1K"), 1 * MB);
+        assert_eq!(parse("1K"), 1 * KB);
         assert_eq!(parse("1Ki"), 1 * KIB);
         assert_eq!(parse("1.5Ki"), (1.5 * KIB as f64) as u64);
         assert_eq!(parse("1KiB"), 1 * KIB);
@@ -38,6 +70,6 @@ mod tests {
         assert_eq!(parse("88TB"), 88 * TB);
         assert_eq!(parse("521TiB"), 521 * TIB);
         assert_eq!(parse("8 PB"), 8 * PB);
-        assert_eq!(parse("12 PB"), 12 * PIB);
+        assert_eq!(parse("12 PiB"), 12 * PIB);
     }
 }


### PR DESCRIPTION
A use case I came around when I wanted the user to provide a ByteSize in my program CLI arguments and using a argument parser like structopt or argh or gumdrop.

Allows parsing a string directly into a ByteSize:

```rust
let size = "128GB".parse::<ByteSize>().unwrap();
```

I'm bad at writing negative test cases though.

Short example of a binary using structopt taking a size as a command line argument:

```rust
use bytesize::ByteSize;
use structopt::StructOpt;

#[derive(Debug, StructOpt)]
struct Args {
    size: ByteSize,
}

fn main() {
    println!("{}", Args::from_args().size);
}
```

PS: the two `'static` lifetime markers I removed because of clippy's suggestion