### PR TITLE
add AddAssign operator to ByteSize

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -256,6 +256,23 @@ impl AddAssign<ByteSize> for ByteSize {
     }
 }
 
+impl<T> Add<T> for ByteSize
+    where T: Into<u64> {
+    type Output = ByteSize;
+    #[inline(always)]
+    fn add(self, rhs: T) -> ByteSize {
+        ByteSize(self.0 + (rhs.into() as u64))
+    }
+}
+
+impl<T> AddAssign<T> for ByteSize
+    where T: Into<u64> {
+    #[inline(always)]
+    fn add_assign(&mut self, rhs: T) {
+        self.0 += rhs.into() as u64;
+    }
+}
+
 impl<T> Mul<T> for ByteSize
     where T: Into<u64> {
     type Output = ByteSize;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,7 +258,6 @@ macro_rules! commutative_op {
     };
 }
 
-commutative_op!(usize);
 commutative_op!(u64);
 commutative_op!(u32);
 commutative_op!(u16);
@@ -303,8 +302,6 @@ mod tests {
     fn test_arithmetic_primitives() {
         let mut x = ByteSize::mb(1);
 
-        assert_eq!((x + MB as usize).as_u64(), 2_000_000);
-
         assert_eq!((x + MB as u64).as_u64(), 2_000_000);
 
         assert_eq!((x + MB as u32).as_u64(), 2_000_000);
@@ -313,12 +310,11 @@ mod tests {
 
         assert_eq!((x + B as u8).as_u64(), 1_000_001);
 
-        x += MB as usize;
         x += MB as u64;
         x += MB as u32;
         x += 10 as u16;
         x += 1 as u8;
-        assert_eq!(x.as_u64(), 4_000_011);
+        assert_eq!(x.as_u64(), 3_000_011);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,23 +215,6 @@ impl Debug for ByteSize {
     }
 }
 
-impl<T> Add<T> for ByteSize
-    where T: Into<u64> {
-    type Output = ByteSize;
-    #[inline(always)]
-    fn add(self, rhs: T) -> ByteSize {
-        ByteSize(self.0 + (rhs.into() as u64))
-    }
-}
-
-impl<T> AddAssign<T> for ByteSize
-    where T: Into<u64> {
-    #[inline(always)]
-    fn add_assign(&mut self, rhs: T) {
-        self.0 += rhs.into() as u64;
-    }
-}
-
 macro_rules! commutative_op {
     ($t:ty) => {
         impl Add<ByteSize> for $t {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,7 +216,7 @@ impl Debug for ByteSize {
 }
 
 impl<T> Add<T> for ByteSize
-    where T: Into<u64>{
+    where T: Into<u64> {
     type Output = ByteSize;
     #[inline(always)]
     fn add(self, rhs: T) -> ByteSize {
@@ -224,15 +224,16 @@ impl<T> Add<T> for ByteSize
     }
 }
 
-
-impl<T> AddAssign<T> for ByteSize where T: Into<u64>{
+impl<T> AddAssign<T> for ByteSize
+    where T: Into<u64> {
     #[inline(always)]
     fn add_assign(&mut self, rhs: T) {
         self.0 += rhs.into() as u64;
     }
 }
 
-impl<T> Mul<T> for ByteSize where T: Into<u64>{
+impl<T> Mul<T> for ByteSize
+    where T: Into<u64> {
     type Output = ByteSize;
     #[inline(always)]
     fn mul(self, rhs: T) -> ByteSize {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@
 extern crate serde;
 
 use std::fmt::{Debug, Display, Formatter, Result};
-use std::ops::{Add, AddAssign, Mul};
+use std::ops::{Add, AddAssign, Mul, MulAssign};
 
 /// byte size for 1 byte
 pub const B: u64 = 1;
@@ -241,6 +241,14 @@ impl<T> Mul<T> for ByteSize
     }
 }
 
+impl<T> MulAssign<T> for ByteSize
+    where T: Into<u64> {
+    #[inline(always)]
+    fn mul_assign(&mut self, rhs: T) {
+        self.0 *= rhs.into() as u64;
+    }
+}
+
 macro_rules! commutative_op {
     ($t:ty) => {
         impl Add<ByteSize> for $t {
@@ -299,6 +307,8 @@ mod tests {
 
         x += y;
         assert_eq!(x.as_u64(), 1_100_000);
+        x *= 2u64;
+        assert_eq!(x.as_u64(), 2_200_000);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -232,23 +232,6 @@ impl<T> AddAssign<T> for ByteSize
     }
 }
 
-impl<T> Mul<T> for ByteSize
-    where T: Into<u64> {
-    type Output = ByteSize;
-    #[inline(always)]
-    fn mul(self, rhs: T) -> ByteSize {
-        ByteSize(self.0 * (rhs.into() as u64))
-    }
-}
-
-impl<T> MulAssign<T> for ByteSize
-    where T: Into<u64> {
-    #[inline(always)]
-    fn mul_assign(&mut self, rhs: T) {
-        self.0 *= rhs.into() as u64;
-    }
-}
-
 macro_rules! commutative_op {
     ($t:ty) => {
         impl Add<ByteSize> for $t {
@@ -287,6 +270,23 @@ impl AddAssign<ByteSize> for ByteSize {
     #[inline(always)]
     fn add_assign(&mut self, rhs: ByteSize) {
         self.0 += rhs.0
+    }
+}
+
+impl<T> Mul<T> for ByteSize
+    where T: Into<u64> {
+    type Output = ByteSize;
+    #[inline(always)]
+    fn mul(self, rhs: T) -> ByteSize {
+        ByteSize(self.0 * (rhs.into() as u64))
+    }
+}
+
+impl<T> MulAssign<T> for ByteSize
+    where T: Into<u64> {
+    #[inline(always)]
+    fn mul_assign(&mut self, rhs: T) {
+        self.0 *= rhs.into() as u64;
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,36 +215,38 @@ impl Debug for ByteSize {
     }
 }
 
+impl<T> Add<T> for ByteSize
+    where T: Into<u64>{
+    type Output = ByteSize;
+    #[inline(always)]
+    fn add(self, rhs: T) -> ByteSize {
+        ByteSize(self.0 + (rhs.into() as u64))
+    }
+}
+
+
+impl<T> AddAssign<T> for ByteSize where T: Into<u64>{
+    #[inline(always)]
+    fn add_assign(&mut self, rhs: T) {
+        self.0 += rhs.into() as u64;
+    }
+}
+
+impl<T> Mul<T> for ByteSize where T: Into<u64>{
+    type Output = ByteSize;
+    #[inline(always)]
+    fn mul(self, rhs: T) -> ByteSize {
+        ByteSize(self.0 * (rhs.into() as u64))
+    }
+}
+
 macro_rules! commutative_op {
     ($t:ty) => {
-        impl Add<$t> for ByteSize {
-            type Output = ByteSize;
-            #[inline(always)]
-            fn add(self, rhs: $t) -> ByteSize {
-                ByteSize(self.0 + (rhs as u64))
-            }
-        }
-
         impl Add<ByteSize> for $t {
             type Output = ByteSize;
             #[inline(always)]
             fn add(self, rhs: ByteSize) -> ByteSize {
                 ByteSize(rhs.0 + (self as u64))
-            }
-        }
-
-        impl AddAssign<$t> for ByteSize {
-            #[inline(always)]
-            fn add_assign(&mut self, rhs: $t) {
-                self.0 += rhs as u64;
-            }
-        }
-
-        impl Mul<$t> for ByteSize {
-            type Output = ByteSize;
-            #[inline(always)]
-            fn mul(self, rhs: $t) -> ByteSize {
-                ByteSize(self.0 * (rhs as u64))
             }
         }
 


### PR DESCRIPTION
While using `ByteSize`, I found out that I was missing `AddAssign` operator.

This pr should allow the following

```rust
let mut x = ByteSize::mb(1);
let y = ByteSize::mb(1);
x += y;
```