### PR TITLE
Integrate Arbitrary Feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ keywords = ["byte", "byte-size", "utility", "human-readable", "format"]
 license = "Apache-2.0"
 
 [dependencies]
+arbitrary = { version = "1.3.0", optional = true }
 serde = { version = "1.0.185", optional = true }
 
 [dev-dependencies]
@@ -20,5 +21,6 @@ serde_json = "1.0.105"
 toml = "0.7.6"
 
 [features]
+arbitrary = ["dep:arbitrary"]
 default = []
 serde = ["dep:serde"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,8 @@
 
 mod parse;
 
+#[cfg(feature = "arbitrary")]
+extern crate arbitrary;
 #[cfg(feature = "serde")]
 extern crate serde;
 #[cfg(feature = "serde")]
@@ -110,6 +112,7 @@ pub fn pib<V: Into<u64>>(size: V) -> u64 {
 
 /// Byte size representation
 #[derive(Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Default)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ByteSize(pub u64);
 
 impl ByteSize {
@@ -208,7 +211,7 @@ pub fn to_string(bytes: u64, si_prefix: bool) -> String {
 }
 
 impl Display for ByteSize {
-    fn fmt(&self, f: &mut Formatter) ->fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         f.pad(&to_string(self.0, false))
     }
 }
@@ -261,7 +264,9 @@ impl AddAssign<ByteSize> for ByteSize {
 }
 
 impl<T> Add<T> for ByteSize
-    where T: Into<u64> {
+where
+    T: Into<u64>,
+{
     type Output = ByteSize;
     #[inline(always)]
     fn add(self, rhs: T) -> ByteSize {
@@ -270,7 +275,9 @@ impl<T> Add<T> for ByteSize
 }
 
 impl<T> AddAssign<T> for ByteSize
-    where T: Into<u64> {
+where
+    T: Into<u64>,
+{
     #[inline(always)]
     fn add_assign(&mut self, rhs: T) {
         self.0 += rhs.into() as u64;
@@ -278,7 +285,9 @@ impl<T> AddAssign<T> for ByteSize
 }
 
 impl<T> Mul<T> for ByteSize
-    where T: Into<u64> {
+where
+    T: Into<u64>,
+{
     type Output = ByteSize;
     #[inline(always)]
     fn mul(self, rhs: T) -> ByteSize {
@@ -287,7 +296,9 @@ impl<T> Mul<T> for ByteSize
 }
 
 impl<T> MulAssign<T> for ByteSize
-    where T: Into<u64> {
+where
+    T: Into<u64>,
+{
     #[inline(always)]
     fn mul_assign(&mut self, rhs: T) {
         self.0 *= rhs.into() as u64;


### PR DESCRIPTION
ByteSize does not currently support deriving `Arbitrary`, which is needed to perform fuzz testing. This patch adds a feature flag that, when enabled, will derive `Arbitrary` for `ByteSize`. `cargo fmt` also updated a few lines.

Please see https://rust-fuzz.github.io/book/cargo-fuzz.html for information regarding fuzz testing. More specifically, https://rust-fuzz.github.io/book/cargo-fuzz/structure-aware-fuzzing.html provides information on `Arbitrary`.