### PR TITLE
Make testable about ByteSize::to_string_as in doc example

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,9 +22,11 @@
 //!
 //! It also provides its human readable string as follows:
 //!
-//! ```ignore=
-//!  assert_eq!("482 GiB".to_string(), ByteSize::gb(518).to_string(true));
-//!  assert_eq!("518 GB".to_string(), ByteSize::gb(518).to_string(false));
+//! ```
+//! use bytesize::ByteSize;
+//!
+//! assert_eq!("482.4 GiB", ByteSize::gb(518).to_string_as(true));
+//! assert_eq!("518.0 GB", ByteSize::gb(518).to_string_as(false));
 //! ```
 
 mod parse;


### PR DESCRIPTION
Hi @hyunsik 

I modified the ByteSize::to_string in the documentation comment to match the currently available APIs so that the tests can run.

I thought that the other subtraction operation example should also be modified to match the current API, but should I remove the subtraction example or implement subtraction on ByteSize? I couldn't fix it because I couldn't judge it. If you have a clear answer on which one to do, I would like to fix it and create a new PR.