### PR TITLE
document crate features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,10 @@ license = "Apache-2.0"
 edition = "2018"
 rust-version = "1.60"
 
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]
+all-features = true
+
 [dependencies]
 arbitrary = { version = "1.3.0", optional = true }
 serde = { version = "1.0.185", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "bytesize"
-description = "an utility for human-readable bytes representations"
+description = "a utility for human-readable bytes representations"
 version = "1.4.0-dev"
 authors = ["Hyunsik Choi <hyunsik.choi@gmail.com>"]
 
-homepage = "https://github.com/hyunsik/bytesize/"
-documentation = "https://docs.rs/bytesize/"
-repository = "https://github.com/hyunsik/bytesize/"
-readme = "README.md"
+homepage = "https://github.com/hyunsik/bytesize#readme"
+repository = "https://github.com/hyunsik/bytesize"
 keywords = ["byte", "byte-size", "utility", "human-readable", "format"]
 license = "Apache-2.0"
+edition = "2018"
+rust-version = "1.60"
 
 [dependencies]
 arbitrary = { version = "1.3.0", optional = true }

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ ByteSize is an utility for human-readable byte count representation.
 Features:
 * Pre-defined constants for various size units (e.g., B, Kb, kib, Mb, Mib, Gb, Gib, ... PB)
 * `ByteSize` type which presents size units convertible to different size units.
-* Artimetic operations for `ByteSize`
+* Arithmetic operations for `ByteSize`
 * FromStr impl for `ByteSize`, allowing to parse from string size representations like 1.5KiB and 521TiB.
 * Serde support for binary and human-readable deserializers like JSON
 
@@ -20,12 +20,7 @@ Add this to your Cargo.toml:
 
 ```toml
 [dependencies]
-bytesize = {version = "1.2.0", features = ["serde"]}
-```
-
-and this to your crate root:
-```rust
-extern crate bytesize;
+bytesize = { version = "1.2.0", features = ["serde"] }
 ```
 
 ## Example
@@ -111,8 +106,6 @@ fn assert_display(expected: &str, b: ByteSize) {
 
 ### Arithmetic operations
 ```rust
-extern crate bytesize;
-
 use bytesize::ByteSize;
 
 fn byte_arithmetic_operator() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,16 +27,9 @@
 //! assert_eq!("518.0 GB", ByteSize::gb(518).to_string_as(false));
 //! ```
 
-mod parse;
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
-#[cfg(feature = "arbitrary")]
-extern crate arbitrary;
-#[cfg(feature = "serde")]
-extern crate serde;
-#[cfg(feature = "serde")]
-use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
-#[cfg(feature = "serde")]
-use std::convert::TryFrom;
+mod parse;
 
 use std::fmt::{self, Debug, Display, Formatter};
 use std::ops::{Add, AddAssign, Mul, MulAssign};
@@ -312,14 +305,18 @@ impl<'a> arbitrary::Arbitrary<'a> for ByteSize {
 }
 
 #[cfg(feature = "serde")]
-impl<'de> Deserialize<'de> for ByteSize {
+impl<'de> serde::Deserialize<'de> for ByteSize {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: Deserializer<'de>,
+        D: serde::Deserializer<'de>,
     {
-        struct ByteSizeVistor;
+        use std::convert::TryFrom as _;
 
-        impl<'de> de::Visitor<'de> for ByteSizeVistor {
+        use serde::de;
+
+        struct ByteSizeVisitor;
+
+        impl<'de> de::Visitor<'de> for ByteSizeVisitor {
             type Value = ByteSize;
 
             fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -354,18 +351,18 @@ impl<'de> Deserialize<'de> for ByteSize {
         }
 
         if deserializer.is_human_readable() {
-            deserializer.deserialize_any(ByteSizeVistor)
+            deserializer.deserialize_any(ByteSizeVisitor)
         } else {
-            deserializer.deserialize_u64(ByteSizeVistor)
+            deserializer.deserialize_u64(ByteSizeVisitor)
         }
     }
 }
 
 #[cfg(feature = "serde")]
-impl Serialize for ByteSize {
+impl serde::Serialize for ByteSize {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: Serializer,
+        S: serde::Serializer,
     {
         if serializer.is_human_readable() {
             <str>::serialize(self.to_string().as_str(), serializer)
@@ -499,6 +496,8 @@ mod tests {
     #[cfg(feature = "serde")]
     #[test]
     fn test_serde() {
+        use serde::{Deserialize, Serialize};
+
         #[derive(Serialize, Deserialize)]
         struct S {
             x: ByteSize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,6 @@
 //! ## Example
 //!
 //! ```ignore
-//! extern crate bytesize;
-//!
 //! use bytesize::ByteSize;
 //!
 //! fn byte_arithmetic_operator() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,6 @@ pub fn pib<V: Into<u64>>(size: V) -> u64 {
 
 /// Byte size representation
 #[derive(Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, Default)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct ByteSize(pub u64);
 
 impl ByteSize {
@@ -302,6 +301,13 @@ where
     #[inline(always)]
     fn mul_assign(&mut self, rhs: T) {
         self.0 *= rhs.into() as u64;
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'a> arbitrary::Arbitrary<'a> for ByteSize {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        u64::arbitrary(u).map(Self)
     }
 }
 


### PR DESCRIPTION
blocked on #42 

test with:

```
RUSTDOCFLAGS="--cfg=docsrs" cargo +nightly doc --no-deps --all-features --open
```

example:

![2024-02-19_14 14 24-26b274c8](https://github.com/hyunsik/bytesize/assets/3316789/5daafbca-b5e6-45c4-950d-8557243555aa)
