### PR TITLE
Remove dependency on `arbitrary`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,15 +12,13 @@ keywords = ["byte", "byte-size", "utility", "human-readable", "format"]
 license = "Apache-2.0"
 
 [dependencies]
-arbitrary = { version = "1.3.0", optional = true }
-serde = { version = "1.0.185", optional = true }
+serde = { version = "1.0", optional = true }
 
 [dev-dependencies]
-serde = { version = "1.0.185", features = ["derive"] }
-serde_json = "1.0.105"
-toml = "0.7.6"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+toml = "0.8"
 
 [features]
-arbitrary = ["dep:arbitrary"]
 default = []
 serde = ["dep:serde"]

--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 [![Crates.io Version](https://img.shields.io/crates/v/bytesize.svg)](https://crates.io/crates/bytesize)
 
 
-ByteSize is an utility for human-readable byte count representation.
+ByteSize is a utility for human-readable byte count representation.
 
 Features:
 * Pre-defined constants for various size units (e.g., B, Kb, kib, Mb, Mib, Gb, Gib, ... PB)
 * `ByteSize` type which presents size units convertible to different size units.
-* Artimetic operations for `ByteSize`
+* Arithmetic operations for `ByteSize`
 * FromStr impl for `ByteSize`, allowing to parse from string size representations like 1.5KiB and 521TiB.
 * Serde support for binary and human-readable deserializers like JSON
 
@@ -20,7 +20,7 @@ Add this to your Cargo.toml:
 
 ```toml
 [dependencies]
-bytesize = {version = "1.2.0", features = ["serde"]}
+bytesize = {version = "1.4.0", features = ["serde"]}
 ```
 
 and this to your crate root:


### PR DESCRIPTION
The `arbitrary` crate is not used and the fewer dependencies the better.