### PR TITLE
feat: merge foyer-rs/bytesize back to the OG repo

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,9 @@ name: Rust
 
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
   pull_request:
-    branches: [ main ]
+    branches: [ master ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -57,6 +57,11 @@ jobs:
           RUST_BACKTRACE: 1
         run: |
           cargo llvm-cov test --all-features
+      - name: Run rust doc test
+        env:
+          RUST_BACKTRACE: 1
+        run: |
+          cargo test --doc --all-features
       - uses: codecov/codecov-action@v4
         if: runner.os == 'Linux' && matrix.rust_toolchain == 'stable'
         env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,21 +2,64 @@ name: Rust
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 env:
   CARGO_TERM_COLOR: always
+  CACHE_KEY_SUFFIX: 20240821
 
 jobs:
-  build:
-
-    runs-on: ubuntu-latest
-
+  rust:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        rust_toolchain: [stable, 1.81.0]
+    runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
+      - uses: actions/checkout@v4
+      - name: Install rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust_toolchain }}
+          components: rustfmt, clippy, llvm-tools-preview
+      - name: Cache Cargo home
+        uses: actions/cache@v4
+        id: cache
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}-${{ env.CACHE_KEY_SUFFIX }}-rust-test
+      - name: Install cargo tools
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          cargo install cargo-sort --locked
+      - name: Run rust cargo-sort check
+        # https://github.com/DevinR528/cargo-sort/issues/56
+        if: matrix.os != 'windows-latest'
+        run: |
+          cargo sort -w -c
+      - name: Run rust format check
+        run: |
+          cargo fmt --all -- --check
+      - name: Run rust clippy check
+        run: |
+          cargo clippy --all-features -- -D warnings
+      - if: steps.cache.outputs.cache-hit != 'true'
+        uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Run rust test with coverage
+        env:
+          RUST_BACKTRACE: 1
+        run: |
+          cargo llvm-cov test --all-features
+      - uses: codecov/codecov-action@v4
+        if: runner.os == 'Linux' && matrix.rust_toolchain == 'stable'
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          verbose: true

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,10 @@
+# Changelog
+
+## (reserved for the release date)
+
+Release version v2.0.0
+
+Changes:
+
+- Use SI format by default with `Display`.
+- Use "KiB" for SI unit.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,7 @@
 
 ## (reserved for the release date)
 
-Release version v2.0.0
-
-Changes:
-
+## Unreleased
 - Use SI format by default with `Display`.
 - Use "KiB" for SI unit.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,5 @@
 # Changelog
 
-## (reserved for the release date)
-
 ## Unreleased
 - Use SI format by default with `Display`.
 - Use "KiB" for SI unit.
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-name = "bytesize"
+name = "foyer-bytesize"
 description = "An utility for human-readable bytes representations. Forked from https://github.com/hyunsik/bytesize ."
-version = "1.4.0"
+version = "2.0.0"
 authors = ["Hyunsik Choi <hyunsik.choi@gmail.com>", "MrCroxx <mrcroxx@outlook.com>"]
 edition = "2021"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bytesize"
-description = "An utility for human-readable bytes representations. Forked from https://github.com/hyunsik/bytesize ."
-version = "2.0.0"
+description = "A utility for human-readable bytes representations. Forked from https://github.com/hyunsik/bytesize ."
+version = "1.4.0-dev"
 authors = ["Hyunsik Choi <hyunsik.choi@gmail.com>", "MrCroxx <mrcroxx@outlook.com>"]
 edition = "2021"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
-name = "foyer-bytesize"
+name = "bytesize"
 description = "An utility for human-readable bytes representations. Forked from https://github.com/hyunsik/bytesize ."
 version = "2.0.0"
 authors = ["Hyunsik Choi <hyunsik.choi@gmail.com>", "MrCroxx <mrcroxx@outlook.com>"]
 edition = "2021"
 
-homepage = "https://github.com/foyer-rs/bytesize/"
-documentation = "https://docs.rs/foyer-bytesize/"
-repository = "https://github.com/foyer-rs/bytesize/"
+homepage = "https://github.com/hyunsik/bytesize/"
+documentation = "https://docs.rs/bytesize/"
+repository = "https://github.com/hyunsik/bytesize/"
 readme = "README.md"
 keywords = ["byte", "byte-size", "utility", "human-readable", "format"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,24 +1,25 @@
 [package]
 name = "bytesize"
-description = "an utility for human-readable bytes representations"
-version = "1.4.0-dev"
-authors = ["Hyunsik Choi <hyunsik.choi@gmail.com>"]
+description = "An utility for human-readable bytes representations. Forked from https://github.com/hyunsik/bytesize ."
+version = "1.4.0"
+authors = ["Hyunsik Choi <hyunsik.choi@gmail.com>", "MrCroxx <mrcroxx@outlook.com>"]
+edition = "2021"
 
-homepage = "https://github.com/hyunsik/bytesize/"
-documentation = "https://docs.rs/bytesize/"
-repository = "https://github.com/hyunsik/bytesize/"
+homepage = "https://github.com/foyer-rs/bytesize/"
+documentation = "https://docs.rs/foyer-bytesize/"
+repository = "https://github.com/foyer-rs/bytesize/"
 readme = "README.md"
 keywords = ["byte", "byte-size", "utility", "human-readable", "format"]
 license = "Apache-2.0"
 
 [dependencies]
-arbitrary = { version = "1.3.0", optional = true }
-serde = { version = "1.0.185", optional = true }
+arbitrary = { version = "1", features = ["derive"], optional = true }
+serde = { version = "1", optional = true }
 
 [dev-dependencies]
-serde = { version = "1.0.185", features = ["derive"] }
-serde_json = "1.0.105"
-toml = "0.7.6"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+toml = "0.8"
 
 [features]
 arbitrary = ["dep:arbitrary"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+SHELL := /bin/bash
+.PHONY: all
+
+all:
+	cargo sort -w
+	cargo fmt --all
+	cargo clippy --all-features
+	RUST_BACKTRACE=1 cargo test --all-features

--- a/README.md
+++ b/README.md
@@ -21,13 +21,15 @@ Features:
 - Use SI format by default with `Display`.
 - Use "KiB" for SI unit.
 
+Considering the changes, the version of `foyer-bytesize` crate starts from "2" to differ from the original `bytesize` crate.
+
 ## Usage
 
 Add this to your Cargo.toml:
 
 ```toml
 [dependencies]
-bytesize = { package = "foyer-bytesize", version = "1", features = ["serde"]}
+bytesize = { package = "foyer-bytesize", version = "2", features = ["serde"]}
 ```
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -1,18 +1,25 @@
 ## ByteSize
+
 [![Rust](https://github.com/foyer-rs/bytesize/actions/workflows/rust.yml/badge.svg)](https://github.com/foyer-rs/bytesize/actions/workflows/rust.yml)
 [![Crates.io Version](https://img.shields.io/crates/v/foyer-bytesize.svg)](https://crates.io/crates/foyer-bytesize)
 
+Forked from https://github.com/hyunsik/bytesize .
 
 ByteSize is an utility for human-readable byte count representation.
 
 Features:
-* Pre-defined constants for various size units (e.g., B, Kb, kib, Mb, Mib, Gb, Gib, ... PB)
+* Pre-defined constants for various size units (e.g., B, Kb, Kib, Mb, Mib, Gb, Gib, ... PB)
 * `ByteSize` type which presents size units convertible to different size units.
 * Artimetic operations for `ByteSize`
 * FromStr impl for `ByteSize`, allowing to parse from string size representations like 1.5KiB and 521TiB.
 * Serde support for binary and human-readable deserializers like JSON
 
-[API Documentation](https://docs.rs/bytesize/)
+[API Documentation](https://docs.rs/foyer-bytesize/)
+
+### Differences from the original `bytesize`
+
+- Use SI format by default with `Display`.
+- Use "KiB" for SI unit.
 
 ## Usage
 
@@ -24,84 +31,71 @@ bytesize = { package = "foyer-bytesize", version = "1", features = ["serde"]}
 ```
 
 ## Example
+
 ### Human readable representations (SI unit and Binary unit)
+
 ```rust
-#[allow(dead_code)]
-fn assert_display(expected: &str, b: ByteSize) {
-  assert_eq!(expected, format!("{}", b));
-}
+    fn assert_display(expected: &str, b: ByteSize) {
+        assert_eq!(expected, format!("{}", b));
+    }
 
-#[test]
-  fn test_display() {
-    assert_display("215 B", ByteSize(215));
-    assert_display("215 B", ByteSize::b(215));
-    assert_display("1.0 KB", ByteSize::kb(1));
-    assert_display("301.0 KB", ByteSize::kb(301));
-    assert_display("419.0 MB", ByteSize::mb(419));
-    assert_display("518.0 GB", ByteSize::gb(518));
-    assert_display("815.0 TB", ByteSize::tb(815));
-    assert_display("609.0 PB", ByteSize::pb(609));
-  }
+    #[test]
+    fn test_display() {
+        assert_display("215 B", ByteSize::b(215));
+        assert_display("1.0 KiB", ByteSize::kib(1));
+        assert_display("301.0 KiB", ByteSize::kib(301));
+        assert_display("419.0 MiB", ByteSize::mib(419));
+        assert_display("518.0 GiB", ByteSize::gib(518));
+        assert_display("815.0 TiB", ByteSize::tib(815));
+        assert_display("609.0 PiB", ByteSize::pib(609));
+    }
 
-  fn assert_to_string(expected: &str, b: ByteSize, si: bool) {
-    assert_eq!(expected.to_string(), b.to_string_as(si));
-  }
+    #[test]
+    fn test_display_alignment() {
+        assert_eq!("|357 B     |", format!("|{:10}|", ByteSize(357)));
+        assert_eq!("|     357 B|", format!("|{:>10}|", ByteSize(357)));
+        assert_eq!("|357 B     |", format!("|{:<10}|", ByteSize(357)));
+        assert_eq!("|  357 B   |", format!("|{:^10}|", ByteSize(357)));
 
-  #[test]
-  fn test_to_string() {
-    assert_to_string("215 B", ByteSize(215), true);
-    assert_to_string("215 B", ByteSize(215), false);
+        assert_eq!("|-----357 B|", format!("|{:->10}|", ByteSize(357)));
+        assert_eq!("|357 B-----|", format!("|{:-<10}|", ByteSize(357)));
+        assert_eq!("|--357 B---|", format!("|{:-^10}|", ByteSize(357)));
+    }
 
-    assert_to_string("215 B", ByteSize::b(215), true);
-    assert_to_string("215 B", ByteSize::b(215), false);
+    fn assert_to_string(expected: &str, b: ByteSize, si: bool) {
+        assert_eq!(expected.to_string(), b.to_string_as(si));
+    }
 
-    assert_to_string("1.0 kiB", ByteSize::kib(1), true);
-    assert_to_string("1.0 KB", ByteSize::kib(1), false);
+    #[test]
+    fn test_to_string_as() {
+        assert_to_string("215 B", ByteSize::b(215), true);
+        assert_to_string("215 B", ByteSize::b(215), false);
 
-    assert_to_string("293.9 kiB", ByteSize::kb(301), true);
-    assert_to_string("301.0 KB", ByteSize::kb(301), false);
+        assert_to_string("1.0 KiB", ByteSize::kib(1), true);
+        assert_to_string("1.0 KB", ByteSize::kib(1), false);
 
-    assert_to_string("1.0 MiB", ByteSize::mib(1), true);
-    assert_to_string("1048.6 KB", ByteSize::mib(1), false);
+        assert_to_string("293.9 KiB", ByteSize::kb(301), true);
+        assert_to_string("301.0 KB", ByteSize::kb(301), false);
 
-    assert_to_string("399.6 MiB", ByteSize::mb(419), true);
-    assert_to_string("419.0 MB", ByteSize::mb(419), false);
+        assert_to_string("1.0 MiB", ByteSize::mib(1), true);
+        assert_to_string("1048.6 KB", ByteSize::mib(1), false);
 
-    assert_to_string("482.4 GiB", ByteSize::gb(518), true);
-    assert_to_string("518.0 GB", ByteSize::gb(518), false);
+        // a bug case: https://github.com/flang-project/bytesize/issues/8
+        assert_to_string("1.9 GiB", ByteSize::mib(1907), true);
+        assert_to_string("2.0 GB", ByteSize::mib(1908), false);
 
-    assert_to_string("741.2 TiB", ByteSize::tb(815), true);
-    assert_to_string("815.0 TB", ByteSize::tb(815), false);
+        assert_to_string("399.6 MiB", ByteSize::mb(419), true);
+        assert_to_string("419.0 MB", ByteSize::mb(419), false);
 
-    assert_to_string("540.9 PiB", ByteSize::pb(609), true);
-    assert_to_string("609.0 PB", ByteSize::pb(609), false);
-  }
+        assert_to_string("482.4 GiB", ByteSize::gb(518), true);
+        assert_to_string("518.0 GB", ByteSize::gb(518), false);
 
-  #[test]
-  fn test_parsing_from_str() {
-      // shortcut for writing test cases
-      fn parse(s: &str) -> u64 {
-          s.parse::<ByteSize>().unwrap().0
-      }
+        assert_to_string("741.2 TiB", ByteSize::tb(815), true);
+        assert_to_string("815.0 TB", ByteSize::tb(815), false);
 
-      assert_eq!("0".parse::<ByteSize>().unwrap().0, 0);
-      assert_eq!(parse("0"), 0);
-      assert_eq!(parse("500"), 500);
-      assert_eq!(parse("1K"), Unit::KiloByte * 1);
-      assert_eq!(parse("1Ki"), Unit::KibiByte * 1);
-      assert_eq!(parse("1.5Ki"), (1.5 * Unit::KibiByte) as u64);
-      assert_eq!(parse("1KiB"), 1 * Unit::KibiByte);
-      assert_eq!(parse("1.5KiB"), (1.5 * Unit::KibiByte) as u64);
-      assert_eq!(parse("3 MB"), Unit::MegaByte * 3);
-      assert_eq!(parse("4 MiB"), Unit::MebiByte * 4);
-      assert_eq!(parse("6 GB"), 6 * Unit::GigaByte);
-      assert_eq!(parse("4 GiB"), 4 * Unit::GibiByte);
-      assert_eq!(parse("88TB"), 88 * Unit::TeraByte);
-      assert_eq!(parse("521TiB"), 521 * Unit::TebiByte);
-      assert_eq!(parse("8 PB"), 8 * Unit::PetaByte);
-      assert_eq!(parse("8P"), 8 * Unit::PetaByte);
-      assert_eq!(parse("12 PiB"), 12 * Unit::PebiByte);
-  }
+        assert_to_string("540.9 PiB", ByteSize::pb(609), true);
+        assert_to_string("609.0 PB", ByteSize::pb(609), false);
+    }
 ```
 
 ### Arithmetic operations

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Add this to your Cargo.toml:
 ```toml
 [dependencies]
 bytesize = { package = "foyer-bytesize", version = "1", features = ["serde"]}
+```
 
 ## Example
 ### Human readable representations (SI unit and Binary unit)
@@ -105,8 +106,6 @@ fn assert_display(expected: &str, b: ByteSize) {
 
 ### Arithmetic operations
 ```rust
-extern crate bytesize;
-
 use bytesize::ByteSize;
 
 fn byte_arithmetic_operator() {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## ByteSize
 
-[![Rust](https://github.com/hyunsik/bytesize/actions/workflows/rust.yml/badge.svg)](https://github.com/hyunsik/bytesize/actions/workflows/rust.yml)
+[![CI](https://github.com/hyunsik/bytesize/actions/workflows/rust.yml/badge.svg)](https://github.com/hyunsik/bytesize/actions/workflows/rust.yml)
 [![Crates.io Version](https://img.shields.io/crates/v/bytesize.svg)](https://crates.io/crates/bytesize)
 
 Forked from https://github.com/hyunsik/bytesize .

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## ByteSize
-[![Build Status](https://travis-ci.org/foyer-rs/bytesize.svg?branch=master)](https://travis-ci.org/foyer-rs/bytesize)
+[![Rust](https://github.com/foyer-rs/bytesize/actions/workflows/rust.yml/badge.svg)](https://github.com/foyer-rs/bytesize/actions/workflows/rust.yml)
 [![Crates.io Version](https://img.shields.io/crates/v/foyer-bytesize.svg)](https://crates.io/crates/foyer-bytesize)
 
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## ByteSize
 
-[![Rust](https://github.com/foyer-rs/bytesize/actions/workflows/rust.yml/badge.svg)](https://github.com/foyer-rs/bytesize/actions/workflows/rust.yml)
-[![Crates.io Version](https://img.shields.io/crates/v/foyer-bytesize.svg)](https://crates.io/crates/foyer-bytesize)
+[![Rust](https://github.com/hyunsik/bytesize/actions/workflows/rust.yml/badge.svg)](https://github.com/hyunsik/bytesize/actions/workflows/rust.yml)
+[![Crates.io Version](https://img.shields.io/crates/v/bytesize.svg)](https://crates.io/crates/bytesize)
 
 Forked from https://github.com/hyunsik/bytesize .
 
@@ -14,14 +14,7 @@ Features:
 * FromStr impl for `ByteSize`, allowing to parse from string size representations like 1.5KiB and 521TiB.
 * Serde support for binary and human-readable deserializers like JSON
 
-[API Documentation](https://docs.rs/foyer-bytesize/)
-
-### Differences from the original `bytesize`
-
-- Use SI format by default with `Display`.
-- Use "KiB" for SI unit.
-
-Considering the changes, the version of `foyer-bytesize` crate starts from "2" to differ from the original `bytesize` crate.
+[API Documentation](https://docs.rs/bytesize/)
 
 ## Usage
 
@@ -29,7 +22,7 @@ Add this to your Cargo.toml:
 
 ```toml
 [dependencies]
-bytesize = { package = "foyer-bytesize", version = "2", features = ["serde"]}
+bytesize = { version = "2", features = ["serde"]}
 ```
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## ByteSize
-[![Build Status](https://travis-ci.org/hyunsik/bytesize.svg?branch=master)](https://travis-ci.org/hyunsik/bytesize)
-[![Crates.io Version](https://img.shields.io/crates/v/bytesize.svg)](https://crates.io/crates/bytesize)
+[![Build Status](https://travis-ci.org/foyer-rs/bytesize.svg?branch=master)](https://travis-ci.org/foyer-rs/bytesize)
+[![Crates.io Version](https://img.shields.io/crates/v/foyer-bytesize.svg)](https://crates.io/crates/foyer-bytesize)
 
 
 ByteSize is an utility for human-readable byte count representation.
@@ -20,13 +20,7 @@ Add this to your Cargo.toml:
 
 ```toml
 [dependencies]
-bytesize = {version = "1.2.0", features = ["serde"]}
-```
-
-and this to your crate root:
-```rust
-extern crate bytesize;
-```
+bytesize = { package = "foyer-bytesize", version = "1", features = ["serde"]}
 
 ## Example
 ### Human readable representations (SI unit and Binary unit)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@
 //! It also provides its human readable string as follows:
 //!
 //! ```
+//! # use foyer_bytesize as bytesize;
 //! use bytesize::ByteSize;
 //!
 //! assert_eq!("482.4 GiB", ByteSize::gb(518).to_string_as(true));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@ pub const TIB: u64 = 1_099_511_627_776;
 pub const PIB: u64 = 1_125_899_906_842_624;
 
 static UNITS: &str = "KMGTPE";
-static UNITS_SI: &str = "kMGTPE";
+static UNITS_SI: &str = "KMGTPE";
 static LN_KB: f64 = 6.931471806; // ln 1024
 static LN_KIB: f64 = 6.907755279; // ln 1000
 
@@ -212,7 +212,7 @@ pub fn to_string(bytes: u64, si_prefix: bool) -> String {
 
 impl Display for ByteSize {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        f.pad(&to_string(self.0, false))
+        f.pad(&to_string(self.0, true))
     }
 }
 
@@ -425,12 +425,12 @@ mod tests {
     #[test]
     fn test_display() {
         assert_display("215 B", ByteSize::b(215));
-        assert_display("1.0 KB", ByteSize::kb(1));
-        assert_display("301.0 KB", ByteSize::kb(301));
-        assert_display("419.0 MB", ByteSize::mb(419));
-        assert_display("518.0 GB", ByteSize::gb(518));
-        assert_display("815.0 TB", ByteSize::tb(815));
-        assert_display("609.0 PB", ByteSize::pb(609));
+        assert_display("1.0 KiB", ByteSize::kib(1));
+        assert_display("301.0 KiB", ByteSize::kib(301));
+        assert_display("419.0 MiB", ByteSize::mib(419));
+        assert_display("518.0 GiB", ByteSize::gib(518));
+        assert_display("815.0 TiB", ByteSize::tib(815));
+        assert_display("609.0 PiB", ByteSize::pib(609));
     }
 
     #[test]
@@ -454,10 +454,10 @@ mod tests {
         assert_to_string("215 B", ByteSize::b(215), true);
         assert_to_string("215 B", ByteSize::b(215), false);
 
-        assert_to_string("1.0 kiB", ByteSize::kib(1), true);
+        assert_to_string("1.0 KiB", ByteSize::kib(1), true);
         assert_to_string("1.0 KB", ByteSize::kib(1), false);
 
-        assert_to_string("293.9 kiB", ByteSize::kb(301), true);
+        assert_to_string("293.9 KiB", ByteSize::kb(301), true);
         assert_to_string("301.0 KB", ByteSize::kb(301), false);
 
         assert_to_string("1.0 MiB", ByteSize::mib(1), true);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,6 @@
 //! It also provides its human readable string as follows:
 //!
 //! ```
-//! # use foyer_bytesize as bytesize;
 //! use bytesize::ByteSize;
 //!
 //! assert_eq!("482.4 GiB", ByteSize::gb(518).to_string_as(true));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,6 @@
 //! ## Example
 //!
 //! ```ignore
-//! extern crate bytesize;
-//!
 //! use bytesize::ByteSize;
 //!
 //! fn byte_arithmetic_operator() {
@@ -199,7 +197,7 @@ pub fn to_string(bytes: u64, si_prefix: bool) -> String {
     } else {
         let size = bytes as f64;
         let exp = match (size.ln() / unit_base) as usize {
-            e if e == 0 => 1,
+            0 => 1,
             e => e,
         };
 
@@ -272,7 +270,7 @@ where
     type Output = ByteSize;
     #[inline(always)]
     fn add(self, rhs: T) -> ByteSize {
-        ByteSize(self.0 + (rhs.into() as u64))
+        ByteSize(self.0 + (rhs.into()))
     }
 }
 
@@ -282,7 +280,7 @@ where
 {
     #[inline(always)]
     fn add_assign(&mut self, rhs: T) {
-        self.0 += rhs.into() as u64;
+        self.0 += rhs.into();
     }
 }
 
@@ -293,7 +291,7 @@ where
     type Output = ByteSize;
     #[inline(always)]
     fn mul(self, rhs: T) -> ByteSize {
-        ByteSize(self.0 * (rhs.into() as u64))
+        ByteSize(self.0 * rhs.into())
     }
 }
 
@@ -303,7 +301,7 @@ where
 {
     #[inline(always)]
     fn mul_assign(&mut self, rhs: T) {
-        self.0 *= rhs.into() as u64;
+        self.0 *= rhs.into();
     }
 }
 


### PR DESCRIPTION
## Changes

- Use SI format by default with Display.
- Use "KiB" for SI unit.
- Bump to version 2.

## Checklist

- [x] Update README.
- [x] Add changelog.
- [x] Fix CI branch.
- [x] Update package info.

## Related issues & PRs
#49 
